### PR TITLE
cm: Allow LiveDisplay to write to color_enhance

### DIFF
--- a/prebuilt/common/etc/init.local.rc
+++ b/prebuilt/common/etc/init.local.rc
@@ -114,6 +114,8 @@ on boot
     chmod 0660 /sys/devices/virtual/graphics/fb0/rgb
     chown system system /sys/devices/virtual/graphics/fb0/sre
     chmod 0660 /sys/devices/virtual/graphics/fb0/sre
+    chown system system /sys/devices/virtual/graphics/fb0/color_enhance
+    chmod 0660 /sys/devices/virtual/graphics/fb0/color_enhance
 
     # Define TCP delayed ack settings for WiFi & LTE
     chown system system /sys/kernel/ipv4/tcp_delack_seg

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -47,6 +47,7 @@
 /sys/devices/virtual/graphics/fb0/cabc          u:object_r:livedisplay_sysfs:s0
 /sys/devices/virtual/graphics/fb0/rgb           u:object_r:livedisplay_sysfs:s0
 /sys/devices/virtual/graphics/fb0/sre           u:object_r:livedisplay_sysfs:s0
+/sys/devices/virtual/graphics/fb0/color_enhance u:object_r:livedisplay_sysfs:s0
 
 # fsck
 /system/bin/fsck\.ntfs                          u:object_r:fsck_exec:s0


### PR DESCRIPTION
The proper permissions for the color_enhance sysfs node weren't
being set, rendering the color enhancement switch useless.

Set the proper permissions for LiveDisplay to toggle color enhancement.

Change-Id: Ic8dba8953b73a497cb01a645834c0e7934092b38