### PR TITLE
cmsdk-api-coverage: Don't prepend ANDROID_BUILD_TOP to file path

### DIFF
--- a/build/tasks/generate_cmsdk_coverage.mk
+++ b/build/tasks/generate_cmsdk_coverage.mk
@@ -59,7 +59,7 @@ endif
 define generate-cm-coverage-report
 	$(hide) mkdir -p $(dir $@)
 	$(hide) $(PRIVATE_CMSDK_API_COVERAGE_EXE) -d $(PRIVATE_DEXDEPS_EXE) -a $(PRIVATE_API_XML_DESC) -f $(3) -o $@ $(2) -cm
-	@ echo $(1): file://$(ANDROID_BUILD_TOP)/$@
+	@ echo $(1): file://$@
 endef
 
 # Reset temp vars


### PR DESCRIPTION
$@ already contains the full path of the output, so no need
to prepend ANDROID_BUILD_TOP to the path

Change-Id: Ieeeb9fa16352e80b878cddb89b1e7c04b82ab43c