### PR TITLE
themes: allow system_server to relabel them dir

### DIFF
--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -9,3 +9,7 @@ allow system_server persist_property_file:file { create_file_perms unlink };
 allow system_server storage_stub_file:dir { getattr };
 
 allow system_server media_rw_data_file:dir r_dir_perms;
+
+# Allow system_server to relabel newly created theme directory for
+# use by the proxied theme service
+allow system_server themeservice_app_data_file:dir relabelto;


### PR DESCRIPTION
On a fresh install the theme service broker creates the initial
theme directory which needs to be relabeled to a themeservice_app_data_File
in order for the brokered theme service to write to this directory

Change-Id: Ifd689a0c619c0e954192749b83a0cacaa945468f
TICKET: NIGHTLIES-3349