### PR TITLE
sepolicy: Address new bluetooth denial

### DIFF
--- a/sepolicy/bluetooth.te
+++ b/sepolicy/bluetooth.te
@@ -1,0 +1,1 @@
+r_dir_file(bluetooth, storage_stub_file);


### PR DESCRIPTION
avc: denied { getattr } for pid=1538 comm="droid.bluetooth" path="/storage/emulated" dev="tmpfs" ino=20607 scontext=u:r:bluetooth:s0 tcontext=u:object_r:storage_stub_file:s0 tclass=dir permissive=

Change-Id: I1456561db1d5e2ebd5634756409c8b198f4f4b64