### PR TITLE
vendor: Add a task for getting prebuilts via http

### DIFF
--- a/build/core/config.mk
+++ b/build/core/config.mk
@@ -1,4 +1,5 @@
 # Copyright (C) 2015 The CyanogenMod Project
+#           (C) 2017 The LineageOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,3 +22,5 @@ FRAMEWORK_CM_API_NEEDS_UPDATE_TEXT := $(TOPDIR)vendor/cm/build/core/apicheck_msg
 
 BUILD_MAVEN_PREBUILT := $(TOP)/vendor/cm/build/core/maven_artifact.mk
 PUBLISH_MAVEN_PREBUILT := $(TOP)/vendor/cm/build/core/maven_artifact_publish.mk
+
+BUILD_HTTP_PREBUILT := $(TOP)/vendor/cm/build/core/http_prebuilt.mk

--- a/build/core/http_prebuilt.mk
+++ b/build/core/http_prebuilt.mk
@@ -1,0 +1,32 @@
+# Copyright (C) 2015 The CyanogenMod Project
+#           (C) 2017 The LineageOS Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifeq ($(strip $(LOCAL_HTTP_PATH)),)
+  $(error LOCAL_HTTP_PATH not defined.)
+endif
+
+ifeq ($(strip $(LOCAL_HTTP_FILENAME)),)
+  $(error LOCAL_HTTP_FILENAME not defined.)
+endif
+
+LOCAL_PREBUILT_MODULE_FILE := $(call intermediates-dir-for,$(LOCAL_MODULE_CLASS),$(LOCAL_MODULE),,COMMON)/$(LOCAL_HTTP_FILENAME)
+
+$(LOCAL_PREBUILT_MODULE_FILE): filename := $(LOCAL_HTTP_FILENAME)
+
+$(LOCAL_PREBUILT_MODULE_FILE):
+	$(hide) curl -L $(LOCAL_HTTP_PATH) --create-dirs -o $(dir $@)/$(filename) --compressed -H "Accept-Encoding: gzip,deflate,sdch"
+	@echo "Download: $@"
+
+include $(BUILD_PREBUILT)

--- a/gello/Android.mk
+++ b/gello/Android.mk
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2016 The CyanogenMod Project
+#           (C) 2017 The LineageOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,11 +42,9 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_BUILT_MODULE_STEM := package.apk
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
 
-LOCAL_MAVEN_REPO := https://maven.cyanogenmod.org/artifactory/gello_prebuilds
-LOCAL_MAVEN_GROUP := org.cyanogenmod
-LOCAL_MAVEN_VERSION := 40
-LOCAL_MAVEN_ARTIFACT := gello
-LOCAL_MAVEN_PACKAGING := apk
+LOCAL_GELLO_VERSION := 40
+LOCAL_HTTP_PATH := https://github.com/LineageOS/android_packages_apps_Gello/releases/download/$(LOCAL_GELLO_VERSION)/gello.apk
+LOCAL_HTTP_FILENAME := gello.apk
 
-include $(BUILD_MAVEN_PREBUILT)
+include $(BUILD_HTTP_PREBUILT)
 endif


### PR DESCRIPTION
 * Gello being our first pawn
 * Use curl instead of wget (more powerful)
 * Ensure the intermediates directory exists prior to download

Change-Id: If19c18638a14a8b9ab55470ae6ee5a2deda2e3ec