### PR TITLE
cm: config: Remove obsolete props

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -11,13 +11,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 endif
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    keyguard.no_require_sim=true \
-    ro.url.legal=http://www.google.com/intl/%s/mobile/android/basic/phone-legal.html \
-    ro.url.legal.android_privacy=http://www.google.com/intl/%s/mobile/android/basic/privacy.html \
-    ro.com.android.wifi-watchlist=GoogleGuest \
-    ro.setupwizard.enterprise_mode=1 \
-    ro.com.android.dateformat=MM-dd-yyyy \
-    ro.com.android.dataroaming=false
+    keyguard.no_require_sim=true
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.build.selinux=1


### PR DESCRIPTION
All usages of ro.com.android.dataroaming default to false.
The rest of the props are no longer used.

Change-Id: I2320e82a1859f8c13f3430a43aa8714186158ee0
(cherry picked from commit 76b66c1ab812e6e4749bec53e03bfc5084c38257)