### PR TITLE
cm: charger: Correct res_create_multi_display_surface() usage

### DIFF
--- a/charger/healthd_board_cm.cpp
+++ b/charger/healthd_board_cm.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 The CyanogenMod Project
+ *               2017 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -301,7 +302,7 @@ void healthd_board_init(struct healthd_config*)
                     // chunk). We are using hard-coded frame.disp_time instead.
 
     rc = res_create_multi_display_surface("charger/cm_battery_scale",
-            &scale_fps, &scale_count, &scale_frames);
+            &scale_count, &scale_fps, &scale_frames);
     if (rc < 0) {
         LOGE("%s: Unable to load battery scale image", __func__);
         return;


### PR DESCRIPTION
Number of frames comes first; frames per second comes after.

This fixes commit 7d2b6d238b586ddcfe5a5c3167371165cbcc5f85.

Change-Id: I06218a01242a327cbb9be08d3efbb3d1e4cbb217
Issue-Id: LINN-11