### PR TITLE
tasks: dt: add flag to optionally compress dt with lz4

### DIFF
--- a/build/tasks/dt_image.mk
+++ b/build/tasks/dt_image.mk
@@ -38,8 +38,16 @@ define build-dtimage-target
     $(hide) chmod a+r $@
 endef
 
+ifeq ($(strip $(BOARD_KERNEL_LZ4C_DT)),true)
+LZ4_DT_IMAGE := $(PRODUCT_OUT)/dt-lz4.img
+endif
+
 $(INSTALLED_DTIMAGE_TARGET): $(DTBTOOL) $(INSTALLED_KERNEL_TARGET)
 	$(build-dtimage-target)
+ifeq ($(strip $(BOARD_KERNEL_LZ4C_DT)),true)
+	lz4 -9 < $@ > $(LZ4_DT_IMAGE) || lz4c -c1 -y $@ $(LZ4_DT_IMAGE)
+	$(hide) $(ACP) $(LZ4_DT_IMAGE) $@
+endif
 	@echo "Made DT image: $@"
 
 ALL_DEFAULT_INSTALLED_MODULES += $(INSTALLED_DTIMAGE_TARGET)


### PR DESCRIPTION
* Gotta save that space somehow. This is in the continuing
  effort to remove custom mkbootimg.mk files in device trees

Change-Id: Ie8b3cedf6e37d1d11c2383dd3590f9908ad7818c