### PR TITLE
cm: remove special access to unused cmfm

### DIFF
--- a/sepolicy/seapp_contexts
+++ b/sepolicy/seapp_contexts
@@ -1,4 +1,3 @@
-user=_app seinfo=platform name=com.cyanogenmod.filemanager domain=untrusted_app type=app_data_file
 #user=theme_man domain=system_app type=system_data_file
 #user=_app seinfo=cmupdater name=com.cyanogenmod.updater domain=system_app type=system_app_data_file
 user=_app seinfo=themeservice name=org.cyanogenmod.themeservice domain=themeservice_app type=themeservice_app_data_file


### PR DESCRIPTION
An user-installed app with the cmfm package name could take advantage of this

Change-Id: I707df3043b9cd73cefcdea4ad0a28632f78089be
Signed-off-by: Joey Rizzoli <joey@lineageos.org>