### PR TITLE
kernel: Include openssl headers and dylibs on darwin

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -262,6 +262,8 @@ endef
 
 ifeq ($(HOST_OS),darwin)
   MAKE_FLAGS += C_INCLUDE_PATH=$(ANDROID_BUILD_TOP)/external/elfutils/libelf/
+  MAKE_FLAGS += C_INCLUDE_PATH=/usr/local/opt/openssl/include
+  MAKE_FLAGS += LIBRARY_PATH=/usr/local/opt/openssl/lib
 endif
 
 ifeq ($(TARGET_KERNEL_MODULES),)


### PR DESCRIPTION
The easiest and best way to get openssl on darwin is using homebrew,
however homebrew refuses to link openssl (and for good reason) in
order to prevent conflicts with Apple's homegrown version. Include
the openssl headers and dylibs from the dir that homebrew installs
openssl to let 4.4 kernels compile.

Change-Id: I06b66768fbdd4855fd57b88100d646ed6e311a59