### PR TITLE
extract_utils: fix extracting XML files containing binary characters

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -768,8 +768,8 @@ function fix_xml() {
     local XML="$1"
     local TEMP_XML="$TMPDIR/`basename "$XML"`.temp"
 
-    grep '^<?xml version' "$XML" > "$TEMP_XML"
-    grep -v '^<?xml version' "$XML" >> "$TEMP_XML"
+    grep -a '^<?xml version' "$XML" > "$TEMP_XML"
+    grep -av '^<?xml version' "$XML" >> "$TEMP_XML"
 
     mv "$TEMP_XML" "$XML"
 }


### PR DESCRIPTION
When a line from the XML file contains a character which grep classifies
as a binary one, it will omit this line at all. Moreover it will append
'Binary file matches' to the stdout. This behavior breaks some XML files.
To fix this issue, let's tell grep to process a binary file as if it were
text.

Change-Id: I6ec5689f73a0926870e502f3f8ee77346b47d05f