### PR TITLE
Show full alarm info

### DIFF
--- a/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -24,4 +24,6 @@
 
 <!-- Should "4G" be shown instead of "LTE" when the network is NETWORK_TYPE_LTE? -->
     <bool name="config_show4GForLTE">false</bool>
+
+    <bool name="quick_settings_show_full_alarm">true</bool>
 </resources>


### PR DESCRIPTION
Globally enable full alarm info in quick settings drawer.

Screenshots: https://goo.gl/photos/ycuvZZFD1ssyWu8B6

This detailed info is pretty useful why not enable it for all devices.

Change-Id: I46ccc3547922b6ab5fdcf8798bd5269b7465a92d
Signed-off-by: Sebastian Haderecker <sebastian.haderecker@gmail.com>